### PR TITLE
feat: support parse PDF array object

### DIFF
--- a/lexer.mbt
+++ b/lexer.mbt
@@ -78,6 +78,10 @@ pub fn tokenize(input : BytesView) -> Array[(Token, Position, Position)] {
         push(FALSE, 5)
         input = rest
       }
+      "null", rest => {
+        push(NULL, 4)
+        input = rest
+      }
 
       // Real numbers (must come before integers to catch decimals)
       // Matches: 123.456, .456, 123., 123.456E10, 123E-5, -123.456, +123.456
@@ -152,6 +156,11 @@ pub fn tokenize(input : BytesView) -> Array[(Token, Position, Position)] {
       }
       "/", rest => {
         push(SOLIDUS, 1)
+        input = rest
+      }
+      "\d+[ \t]+\d+[ \t]+R" as s, rest => {
+        let indirect = tokenize_pdf_indirect(s)
+        push(INDIRECT(indirect), s.length())
         input = rest
       }
 
@@ -395,4 +404,71 @@ fn hex_byte_to_value(c : Byte) -> Int? {
     b'a'..=b'f' => Some(c.to_int() - b'a'.to_int() + 10)
     _ => None
   }
+}
+
+///|
+/// Parse PDF indirect object reference of the form "obj_num gen_num R"
+/// Example: "123 0 R" -> INDIRECT { object_num: 123, generation_num: 0 }
+fn tokenize_pdf_indirect(input : BytesView) -> INDIRECT {
+  // Split the input by whitespace and extract the numbers
+  let mut object_num = 0
+  let mut generation_num = 0
+  let mut current_number = 0
+  let mut parsing_first = true
+  let mut parsing_number = false
+  loop input {
+    // Skip whitespace and find numbers
+    [b' ', .. rest] | [b'\t', .. rest] => {
+      if parsing_number {
+        // Finished parsing a number
+        if parsing_first {
+          object_num = current_number
+          parsing_first = false
+        } else {
+          generation_num = current_number
+          break // We have both numbers, ignore the rest (should be 'R')
+        }
+        current_number = 0
+        parsing_number = false
+      }
+      continue rest
+    }
+
+    // Parse digit characters
+    [b'0'..=b'9' as digit, .. rest] => {
+      parsing_number = true
+      current_number = current_number * 10 + (digit.to_int() - b'0'.to_int())
+      continue rest
+    }
+
+    // Skip 'R' character and any other characters
+    [_, .. rest] => {
+      if parsing_number {
+        // Finished parsing a number
+        if parsing_first {
+          object_num = current_number
+          parsing_first = false
+        } else {
+          generation_num = current_number
+          break // We have both numbers
+        }
+        current_number = 0
+        parsing_number = false
+      }
+      continue rest
+    }
+
+    // End of input
+    [] => {
+      if parsing_number {
+        if parsing_first {
+          object_num = current_number
+        } else {
+          generation_num = current_number
+        }
+      }
+      break
+    }
+  }
+  INDIRECT::{ object_num, generation_num }
 }

--- a/lexer_test.mbt
+++ b/lexer_test.mbt
@@ -666,28 +666,7 @@ test "tokenize complex pdf document structure" {
   ]
 
   // Convert to string representation for easier comparison
-  let token_strings = tokens.map(fn(token) {
-    match token {
-      TRUE => "TRUE"
-      FALSE => "FALSE"
-      LEFT_PARENTHESIS => "LEFT_PARENTHESIS"
-      RIGHT_PARENTHESIS => "RIGHT_PARENTHESIS"
-      LEFT_CURLY_BRACE => "LEFT_CURLY_BRACE"
-      RIGHT_CURLY_BRACE => "RIGHT_CURLY_BRACE"
-      LEFT_SQUARE_BRACKET => "LEFT_SQUARE_BRACKET"
-      RIGHT_SQUARE_BRACKET => "RIGHT_SQUARE_BRACKET"
-      LESS_THAN_SIGN => "LESS_THAN_SIGN"
-      GREATER_THAN_SIGN => "GREATER_THAN_SIGN"
-      SOLIDUS => "SOLIDUS"
-      DICT_BEGIN => "DICT_BEGIN"
-      DICT_END => "DICT_END"
-      INTEGER(n) => "INTEGER(\{n})"
-      REAL(r) => "REAL(\{r})"
-      STRING(s) => "STRING(\{ascii_string_of_bytes(s)})"
-      NAME(n) => "NAME(\{ascii_string_of_bytes(n)})"
-      EOF => "EOF"
-    }
-  })
+  let token_strings = tokens.map(Token::to_string)
   inspect(
     token_strings,
     content=(
@@ -779,6 +758,40 @@ test "tokenize error resilience" {
   inspect(
     tokens,
     content="[TRUE, LEFT_PARENTHESIS, NAME(name), INTEGER(123), FALSE, EOF]",
+  )
+}
+
+///|
+test "tokenize pdf indirect object references" {
+  // Test basic indirect object reference
+  let input1 = b"123 0 R"
+  let tokens1 = tokenize(input1).map(triple => triple.0)
+  inspect(tokens1, content="[INDIRECT(123, 0), EOF]")
+
+  // Test indirect reference with different numbers
+  let input2 = b"456 17 R"
+  let tokens2 = tokenize(input2).map(triple => triple.0)
+  inspect(tokens2, content="[INDIRECT(456, 17), EOF]")
+
+  // Test multiple indirect references
+  let input3 = b"1 0 R 2 0 R 3 5 R"
+  let tokens3 = tokenize(input3).map(triple => triple.0)
+  inspect(
+    tokens3,
+    content="[INDIRECT(1, 0), INDIRECT(2, 0), INDIRECT(3, 5), EOF]",
+  )
+
+  // Test indirect reference with extra whitespace
+  let input4 = b"789  \t 42  \t R"
+  let tokens4 = tokenize(input4).map(triple => triple.0)
+  inspect(tokens4, content="[INDIRECT(789, 42), EOF]")
+
+  // Test mixed content with indirect references
+  let input5 = b"/Parent 3 0 R /Contents 5 0 R"
+  let tokens5 = tokenize(input5).map(triple => triple.0)
+  inspect(
+    tokens5,
+    content="[NAME(Parent), INDIRECT(3, 0), NAME(Contents), INDIRECT(5, 0), EOF]",
   )
 }
 

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -5,5 +5,5 @@
     "moonbitlang/x/fs",
     "illusory0x0/lexer/lexer_bytes"
   ],
-  "warn-list": "-1-6-4-2-7"
+  "warn-list": "-1-2-3-4-6-7"
 }

--- a/parser.mbty
+++ b/parser.mbty
@@ -36,6 +36,9 @@
 
 // PDF Objects:
 
+// Null object, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.9
+%token NULL "null"
+
 // Booleans objects, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.2
 %token TRUE "true"
 %token FALSE "false"
@@ -59,17 +62,40 @@
 // this NAME token contains the leading solidus (/) character
 %token<Bytes> NAME
 
+// Indirect Object, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.10
+%token<INDIRECT> INDIRECT
+
 // Array objects, Dictionary objects and Stream objects aren't terminal symbols.
 
 // here define an EOF token to mark the end of input
-%token EOF 
-
-%left PLUS MINUS
+%token EOF
 
 %% 
 // moonyacc entry point must be declared using `%start <symbol_name>` directive
 // here is the definition of the entry point symbol
-parse  :  
-  |  EOF { $1 }
+parse -> Object :  
+  |  PDF_Array EOF { $1 }
 ;
 
+Atom -> Atom :
+  | NAME { Name($1) }
+  | STRING { String($1) }
+  | INTEGER { Integer($1) }
+  | REAL { Real($1) }
+  | NULL { Null }
+  | TRUE { Boolean(true) }
+  | FALSE { Boolean(false) }
+  | INDIRECT { Indirect($1.object_num) }
+;
+NonEmptyElems -> NonEmptyElems :
+  | Atom { [$1] }
+  | NonEmptyElems Atom { $1.push($2)
+      $1 }
+;
+PDF_Array -> PDF_Array :
+  | LEFT_SQUARE_BRACKET RIGHT_SQUARE_BRACKET { Object::Array([]) }
+  | LEFT_SQUARE_BRACKET NonEmptyElems RIGHT_SQUARE_BRACKET { Array($2) }
+;
+
+
+%%

--- a/parser_declaration.mbt
+++ b/parser_declaration.mbt
@@ -39,6 +39,9 @@ test {
     #|
     #|// PDF Objects:
     #|
+    #|// Null object, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.9
+    #|%token NULL "null"
+    #|
     #|// Booleans objects, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.2
     #|%token TRUE "true"
     #|%token FALSE "false"
@@ -62,36 +65,64 @@ test {
     #|// this NAME token contains the leading solidus (/) character
     #|%token<Bytes> NAME
     #|
+    #|// Indirect Object, see more details in `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.10
+    #|%token<INDIRECT> INDIRECT
+    #|
     #|// Array objects, Dictionary objects and Stream objects aren't terminal symbols.
     #|
     #|// here define an EOF token to mark the end of input
-    #|%token EOF 
-    #|
-    #|%left PLUS MINUS
+    #|%token EOF
     #|
     #|%% 
     #|// moonyacc entry point must be declared using `%start <symbol_name>` directive
     #|// here is the definition of the entry point symbol
-    #|parse  :  
-    #|  |  EOF { $1 }
+    #|parse -> Object :  
+    #|  |  PDF_Array EOF { $1 }
     #|;
     #|
     #|
-  // let expr = [
-  //   rule(fn(lhs : Expr, _ : PLUS, rhs : Expr) -> Expr { Expr::Add(lhs, rhs) }),
-  //   rule(fn(lhs : Expr, _ : MINUS, rhs : Expr) -> Expr { Expr::Minus(lhs, rhs) }),
-  //   rule(fn(value : INT) -> Expr { Expr::LInt(value) }),
-  // ]
   let path = current_source_location().path.replace(
     old="parser_declaration.mbt",
     new="parser.mbty",
   )
   let buffer = StringBuilder::new()
+  let atom = [
+    rule(fn(val : NAME) -> Atom { Name(val) }),
+    rule(fn(val : STRING) -> Atom { String(val) }),
+    rule(fn(val : INTEGER) -> Atom { Integer(val) }),
+    rule(fn(val : REAL) -> Atom { Real(val) }),
+    rule(fn(val : NULL) -> Atom { Null }),
+    rule(fn(val : TRUE) -> Atom { Boolean(true) }),
+    rule(fn(val : FALSE) -> Atom { Boolean(false) }),
+    rule(fn(val : INDIRECT) -> Atom { Indirect(val.object_num) }),
+  ]
+  let array_non_empty_elems = [
+    rule(fn(val : Atom) -> NonEmptyElems { [val] }),
+    rule(fn(acc : NonEmptyElems, val : Atom) -> NonEmptyElems {
+      acc.push(val)
+      acc
+    }),
+  ]
+  let pdf_array = [
+    // Array([]])
+    rule(fn(_ : LEFT_SQUARE_BRACKET, _ : RIGHT_SQUARE_BRACKET) -> PDF_Array {
+      Object::Array([])
+    }),
+    rule(fn(
+      _ : LEFT_SQUARE_BRACKET,
+      array : NonEmptyElems,
+      _ : RIGHT_SQUARE_BRACKET,
+    ) -> PDF_Array {
+      Array(array)
+    }),
+  ]
+  let non_terminal_symbols = [atom, array_non_empty_elems, pdf_array]
 
-  // // dump the non-terminal declaration to the buffer
+  // dump the non-terminal declaration to the buffer
   buffer.write_string(token_decl)
-  // buffer.write_string(NonTerminal::from(expr).emit())
-  // buffer.write_string("\n")
-
+  for non_terminal in non_terminal_symbols {
+    buffer.write_string(NonTerminal::from(non_terminal).emit())
+  }
+  buffer.write_string("\n\n%%\n")
   try! @fs.write_string_to_file(path, buffer.to_string())
 }

--- a/parser_definition.mbt
+++ b/parser_definition.mbt
@@ -14,13 +14,25 @@ priv suberror YYObj_Void
 priv suberror YYObj_Int Int
 
 ///|
-priv suberror YYObj_Unit Unit
+priv suberror YYObj_Atom Atom
 
 ///|
 priv suberror YYObj_Bytes Bytes
 
 ///|
 priv suberror YYObj_Double Double
+
+///|
+priv suberror YYObj_Object Object
+
+///|
+priv suberror YYObj_INDIRECT INDIRECT
+
+///|
+priv suberror YYObj_PDF_Array PDF_Array
+
+///|
+priv suberror YYObj_NonEmptyElems NonEmptyElems
 
 ///|
 typealias (YYSymbol) -> YYDecision as YYState
@@ -50,14 +62,19 @@ priv enum YYSymbol {
   T_SOLIDUS
   T_DICT_BEGIN
   T_DICT_END
+  T_NULL
   T_TRUE
   T_FALSE
   T_INTEGER
   T_REAL
   T_STRING
   T_NAME
+  T_INDIRECT
   T_EOF
   NT_parse
+  NT_Atom
+  NT_NonEmptyElems
+  NT_PDF_Array
   EOI
 }
 
@@ -72,18 +89,221 @@ fn init {
 }
 
 // file:///./parser.mbty
-// 73|     EOF { $1 }
+// 77|     PDF_Array EOF { $1 }
 
 ///|
 fn yy_action_0(
   _last_pos : Position,
   _args : ArrayView[(YYObj, Position, Position)],
 ) -> YYObj {
-  let _dollar1 = ()
-  YYObj_Unit(
+  guard _args[0].0 is YYObj_PDF_Array(_dollar1)
+  YYObj_Object(
     {
       ()
       _dollar1
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 91|    Atom { [$1] }
+
+///|
+fn yy_action_1(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_Atom(_dollar1)
+  YYObj_NonEmptyElems(
+    {
+      ()
+      [_dollar1]
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 81|    NAME { Name($1) }
+
+///|
+fn yy_action_2(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_Bytes(_dollar1)
+  YYObj_Atom(
+    {
+      ()
+      Name(_dollar1)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 82|    STRING { String($1) }
+
+///|
+fn yy_action_3(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_Bytes(_dollar1)
+  YYObj_Atom(
+    {
+      ()
+      String(_dollar1)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 83|    INTEGER { Integer($1) }
+
+///|
+fn yy_action_4(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_Int(_dollar1)
+  YYObj_Atom(
+    {
+      ()
+      Integer(_dollar1)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 84|    REAL { Real($1) }
+
+///|
+fn yy_action_5(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_Double(_dollar1)
+  YYObj_Atom(
+    {
+      ()
+      Real(_dollar1)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 85|    NULL { Null }
+
+///|
+fn yy_action_6(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  YYObj_Atom(
+    {
+      ()
+      Null
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 86|    TRUE { Boolean(true) }
+
+///|
+fn yy_action_7(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  YYObj_Atom(
+    {
+      ()
+      Boolean(true)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 87|    FALSE { Boolean(false) }
+
+///|
+fn yy_action_8(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  YYObj_Atom(
+    {
+      ()
+      Boolean(false)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 88|    INDIRECT { Indirect($1.object_num) }
+
+///|
+fn yy_action_9(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_INDIRECT(_dollar1)
+  YYObj_Atom(
+    {
+      ()
+      Indirect(_dollar1.object_num)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 92|    NonEmptyElems Atom { $1.push($2)
+// 93|      $1 }
+
+///|
+fn yy_action_10(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[0].0 is YYObj_NonEmptyElems(_dollar1)
+  guard _args[1].0 is YYObj_Atom(_dollar2)
+  YYObj_NonEmptyElems(
+    {
+      ()
+      _dollar1.push(_dollar2)
+      _dollar1
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 97|    LEFT_SQUARE_BRACKET NonEmptyElems RIGHT_SQUARE_BRACKET { Array($2) }
+
+///|
+fn yy_action_11(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  guard _args[1].0 is YYObj_NonEmptyElems(_dollar2)
+  YYObj_PDF_Array(
+    {
+      ()
+      Array(_dollar2)
+    },
+  )
+}
+
+// file:///./parser.mbty
+// 96|    LEFT_SQUARE_BRACKET RIGHT_SQUARE_BRACKET { Object::Array([]) }
+
+///|
+fn yy_action_12(
+  _last_pos : Position,
+  _args : ArrayView[(YYObj, Position, Position)],
+) -> YYObj {
+  YYObj_PDF_Array(
+    {
+      ()
+      Object::Array([])
     },
   )
 }
@@ -106,12 +326,14 @@ fn yy_input(
     SOLIDUS => (T_SOLIDUS, YYObj_Void)
     DICT_BEGIN => (T_DICT_BEGIN, YYObj_Void)
     DICT_END => (T_DICT_END, YYObj_Void)
+    NULL => (T_NULL, YYObj_Void)
     TRUE => (T_TRUE, YYObj_Void)
     FALSE => (T_FALSE, YYObj_Void)
     INTEGER(data) => (T_INTEGER, YYObj_Int(data))
     REAL(data) => (T_REAL, YYObj_Double(data))
     STRING(data) => (T_STRING, YYObj_Bytes(data))
     NAME(data) => (T_NAME, YYObj_Bytes(data))
+    INDIRECT(data) => (T_INDIRECT, YYObj_INDIRECT(data))
     EOF => (T_EOF, YYObj_Void)
   }
 }
@@ -120,7 +342,8 @@ fn yy_input(
 fn yy_state_0(_lookahead : YYSymbol) -> YYDecision {
   match _lookahead {
     NT_parse => Shift(yy_state_1)
-    T_EOF => Shift(yy_state_2)
+    T_LEFT_SQUARE_BRACKET => Shift(yy_state_2)
+    NT_PDF_Array => Shift(yy_state_16)
     _ => Error
   }
 }
@@ -132,7 +355,110 @@ fn yy_state_1(_lookahead : YYSymbol) -> YYDecision {
 
 ///|
 fn yy_state_2(_lookahead : YYSymbol) -> YYDecision {
-  ReduceNoLookahead(1, NT_parse, yy_action_0)
+  match _lookahead {
+    T_RIGHT_SQUARE_BRACKET => Shift(yy_state_3)
+    NT_NonEmptyElems => Shift(yy_state_4)
+    T_INDIRECT => Shift(yy_state_7)
+    T_FALSE => Shift(yy_state_8)
+    T_TRUE => Shift(yy_state_9)
+    T_NULL => Shift(yy_state_10)
+    T_REAL => Shift(yy_state_11)
+    T_INTEGER => Shift(yy_state_12)
+    T_STRING => Shift(yy_state_13)
+    T_NAME => Shift(yy_state_14)
+    NT_Atom => Shift(yy_state_15)
+    _ => Error
+  }
+}
+
+///|
+fn yy_state_3(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(2, NT_PDF_Array, yy_action_12)
+}
+
+///|
+fn yy_state_4(_lookahead : YYSymbol) -> YYDecision {
+  match _lookahead {
+    T_RIGHT_SQUARE_BRACKET => Shift(yy_state_5)
+    NT_Atom => Shift(yy_state_6)
+    T_INDIRECT => Shift(yy_state_7)
+    T_FALSE => Shift(yy_state_8)
+    T_TRUE => Shift(yy_state_9)
+    T_NULL => Shift(yy_state_10)
+    T_REAL => Shift(yy_state_11)
+    T_INTEGER => Shift(yy_state_12)
+    T_STRING => Shift(yy_state_13)
+    T_NAME => Shift(yy_state_14)
+    _ => Error
+  }
+}
+
+///|
+fn yy_state_5(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(3, NT_PDF_Array, yy_action_11)
+}
+
+///|
+fn yy_state_6(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(2, NT_NonEmptyElems, yy_action_10)
+}
+
+///|
+fn yy_state_7(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_9)
+}
+
+///|
+fn yy_state_8(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_8)
+}
+
+///|
+fn yy_state_9(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_7)
+}
+
+///|
+fn yy_state_10(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_6)
+}
+
+///|
+fn yy_state_11(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_5)
+}
+
+///|
+fn yy_state_12(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_4)
+}
+
+///|
+fn yy_state_13(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_3)
+}
+
+///|
+fn yy_state_14(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_Atom, yy_action_2)
+}
+
+///|
+fn yy_state_15(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(1, NT_NonEmptyElems, yy_action_1)
+}
+
+///|
+fn yy_state_16(_lookahead : YYSymbol) -> YYDecision {
+  match _lookahead {
+    T_EOF => Shift(yy_state_17)
+    _ => Error
+  }
+}
+
+///|
+fn yy_state_17(_lookahead : YYSymbol) -> YYDecision {
+  ReduceNoLookahead(2, NT_parse, yy_action_0)
 }
 
 ///|
@@ -271,12 +597,14 @@ fn error(
         (T_SOLIDUS, TK_SOLIDUS),
         (T_DICT_BEGIN, TK_DICT_BEGIN),
         (T_DICT_END, TK_DICT_END),
+        (T_NULL, TK_NULL),
         (T_TRUE, TK_TRUE),
         (T_FALSE, TK_FALSE),
         (T_INTEGER, TK_INTEGER),
         (T_REAL, TK_REAL),
         (T_STRING, TK_STRING),
         (T_NAME, TK_NAME),
+        (T_INDIRECT, TK_INDIRECT),
         (T_EOF, TK_EOF),
       ] : Array[(YYSymbol, TokenKind)]) {
     try_add(term.0, term.1)
@@ -291,12 +619,12 @@ fn error(
 pub fn parse(
   tokens : Array[(Token, Position, Position)],
   initial_pos? : Position,
-) -> Unit raise ParseError {
+) -> Object raise ParseError {
   yy_parse(
     tokens,
     yy_state_0,
     it => {
-      guard it is YYObj_Unit(result)
+      guard it is YYObj_Object(result)
       result
     },
     initial_pos?,

--- a/parser_hack_edsl.mbt
+++ b/parser_hack_edsl.mbt
@@ -534,7 +534,7 @@ fn Func::to_production_rule(typ : Func) -> String {
     let parm_name = typ.parms[i].name
     let replacement = "$\{i + 1}"
     // Simple string replacement - replace parameter name with $N
-    body = body.replace(old=parm_name, new=replacement)
+    body = body.replace_all(old=parm_name, new=replacement)
   }
 
   // Format as production rule: "| rule_lhs { body }"
@@ -576,7 +576,7 @@ fn NonTerminal::emit(self : NonTerminal) -> String {
 
   // Format as: "NonTerminal -> NonTerminal :\n  rule1\n  rule2\n;"
   let rules_str = rules.join("\n  ")
-  "\{nonterminal_name} -> \{nonterminal_name} :\n  \{rules_str}\n;"
+  "\{nonterminal_name} -> \{nonterminal_name} :\n  \{rules_str}\n;\n"
 }
 
 ///|

--- a/parser_symbols.mbt
+++ b/parser_symbols.mbt
@@ -6,3 +6,101 @@
 /// here we make MoonBit type corresponding to parser symbol names for simplicity
 /// 
 ///
+
+///|
+/// terminal symbols
+/// 
+///
+
+///|
+/// Terminal symbol: Left parenthesis '('
+type LEFT_PARENTHESIS
+
+///|
+/// Terminal symbol: Right parenthesis ')'
+type RIGHT_PARENTHESIS
+
+///|
+/// Terminal symbol: Left curly brace '{'
+type LEFT_CURLY_BRACE
+
+///|
+/// Terminal symbol: Right curly brace '}'
+type RIGHT_CURLY_BRACE
+
+///|
+/// Terminal symbol: Left square bracket '['
+type LEFT_SQUARE_BRACKET
+
+///|
+/// Terminal symbol: Right square bracket ']'
+type RIGHT_SQUARE_BRACKET
+
+///|
+/// Terminal symbol:  
+struct INDIRECT {
+  object_num : Int
+  generation_num : Int
+} derive(Show, Eq)
+
+///|
+/// Terminal symbol: Less than sign '<'
+type LESS_THAN_SIGN
+
+///|
+/// Terminal symbol: Greater than sign '>'
+type GREATER_THAN_SIGN
+
+///|
+/// Terminal symbol: Solidus '/'
+type SOLIDUS
+
+///|
+/// Terminal symbol: Dictionary begin marker
+type DICT_BEGIN
+
+///|
+/// Terminal symbol: Dictionary end marker
+type DICT_END
+
+///|
+/// Terminal symbol: Boolean true literal
+type TRUE
+
+///|
+/// Terminal symbol: Boolean false literal
+type FALSE
+
+///|
+/// Terminal symbol: End of file marker
+type EOF
+
+///|
+/// Non-terminal symbol: Object represented as Atom
+typealias Object as Atom
+
+///|
+/// Terminal symbol: Null value literal
+type NULL
+
+///|
+/// Non-terminal symbol: Integer represented as Int
+typealias Int as INTEGER
+
+///|
+/// Non-terminal symbol: Real number represented as Double
+typealias Double as REAL
+
+///|
+/// Non-terminal symbol: String represented as Bytes
+typealias Bytes as STRING
+
+///|
+/// Non-terminal symbol: Name represented as Bytes
+typealias Bytes as NAME
+
+///|
+typealias Array[Atom] as NonEmptyElems
+
+///|
+typealias Object as PDF_Array

--- a/parser_test.mbt
+++ b/parser_test.mbt
@@ -1,0 +1,362 @@
+///|
+fn string_of_pdf_object(obj : Object) -> String {
+  let buf = @fmt.Memory::make(@fmt.Format::count(obj), 0)
+  let ofs = @fmt.Format::write(obj, buf, 0)
+  let bytes = bytes_of_memory(buf, ofs)
+  ascii_string_of_bytes(bytes)
+}
+
+///|
+test "basic integer array" {
+  let s = b"[123 323 434]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[123 323 434]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 123], ["Integer", 323], ["Integer", 434]],
+  ])
+}
+
+///|
+test "empty array" {
+  let s = b"[]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[]")
+  @json.inspect(obj, content=["Array", []])
+}
+
+///|
+test "array with single element" {
+  let s = b"[42]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[42]")
+  @json.inspect(obj, content=["Array", [["Integer", 42]]])
+}
+
+///|
+test "array with mixed types" {
+  let s = b"[123 true false null 3.14]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[123 true false null 3.14]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Integer", 123],
+      ["Boolean", true],
+      ["Boolean", false],
+      "Null",
+      ["Real", 3.14],
+    ],
+  ])
+}
+
+///|
+test "array with real numbers" {
+  let s = b"[1.5 -2.7 0.0 123.456]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[1.5 -2.7 0 123.456]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Real", 1.5], ["Real", -2.7], ["Real", 0], ["Real", 123.456]],
+  ])
+}
+
+///|
+test "array with negative integers" {
+  let s = b"[-123 -456 -789]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[-123 -456 -789]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", -123], ["Integer", -456], ["Integer", -789]],
+  ])
+}
+
+///|
+test "array with strings" {
+  let s = b"[<48656C6C6F> <576F726C64>]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[(Hello) (World)]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["String", "Hello"], ["String", "World"]],
+  ])
+}
+
+///|
+test "array with PDF names" {
+  let s = b"[/Type /Font /Subtype]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[Type Font Subtype]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Name", "Type"], ["Name", "Font"], ["Name", "Subtype"]],
+  ])
+}
+
+///|
+test "array with whitespace variations" {
+  let s = b"[ 1   2\t3\n4\r5 ]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[1 2 3 4 5]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Integer", 1],
+      ["Integer", 2],
+      ["Integer", 3],
+      ["Integer", 4],
+      ["Integer", 5],
+    ],
+  ])
+}
+
+///|
+test "array with mixed strings and names" {
+  let s = b"[/Name <48656C6C6F> /Type <576F726C64>]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[Name (Hello) Type (World)]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Name", "Name"],
+      ["String", "Hello"],
+      ["Name", "Type"],
+      ["String", "World"],
+    ],
+  ])
+}
+
+///|
+test "array with boolean values" {
+  let s = b"[true false true false]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[true false true false]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Boolean", true],
+      ["Boolean", false],
+      ["Boolean", true],
+      ["Boolean", false],
+    ],
+  ])
+}
+
+///|
+test "array with null values" {
+  let s = b"[null 123 null false null]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[null 123 null false null]")
+  @json.inspect(obj, content=[
+    "Array",
+    ["Null", ["Integer", 123], "Null", ["Boolean", false], "Null"],
+  ])
+}
+
+///|
+test "array with indirect references" {
+  let s = b"[123 0 R 456 0 R]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[123 0 R 456 0 R]")
+  @json.inspect(obj, content=["Array", [["Indirect", 123], ["Indirect", 456]]])
+}
+
+///|
+test "array with PDF bounding box" {
+  let s = b"[72 72 540 720]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[72 72 540 720]")
+  @json.inspect(obj, content=(["Array",[["Integer",72],["Integer",72],["Integer",540],["Integer",720]]]))
+}
+
+///|
+test "array with PDF dash pattern" {
+  let s = b"[3 2 1 4]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[3 2 1 4]")
+  @json.inspect(obj, content=(["Array",[["Integer",3],["Integer",2],["Integer",1],["Integer",4]]]))
+}
+
+///|
+test "array with scientific notation numbers" {
+  let s = b"[1e5 -2.5e-3 3.14E+2]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[100000 -0.0025 314]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Real", 100000], ["Real", -0.0025], ["Real", 314]],
+  ])
+}
+
+///|
+test "array with zero values" {
+  let s = b"[0 0.0 -0 -0.0]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[0 0 0 0]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 0], ["Real", 0], ["Integer", 0], ["Real", 0]],
+  ])
+}
+
+///|
+test "array with large numbers" {
+  let s = b"[999999999 -999999999 1.7976931348623157e308]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(
+    string_of_pdf_object(obj),
+    content="[999999999 -999999999 1.7976931348623157e+308]",
+  )
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Integer", 999999999],
+      ["Integer", -999999999],
+      ["Real", 1.7976931348623157e+308],
+    ],
+  ])
+}
+
+///|
+test "array with special float values" {
+  let s = b"[0.1 0.01 0.001 10.0 100.0 1000.0]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[0.1 0.01 0.001 10 100 1000]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Real", 0.1],
+      ["Real", 0.01],
+      ["Real", 0.001],
+      ["Real", 10],
+      ["Real", 100],
+      ["Real", 1000],
+    ],
+  ])
+}
+
+///|
+test "array with empty string" {
+  let s = b"[<> /Name <>]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[() Name ()]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["String", ""], ["Name", "Name"], ["String", ""]],
+  ])
+}
+
+///|
+test "array for PDF rectangle" {
+  let s = b"[0 0 612 792]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[0 0 612 792]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 0], ["Integer", 0], ["Integer", 612], ["Integer", 792]],
+  ])
+}
+
+///|
+test "array for PDF transformation matrix" {
+  let s = b"[1 0 0 1 72 720]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[1 0 0 1 72 720]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Integer", 1],
+      ["Integer", 0],
+      ["Integer", 0],
+      ["Integer", 1],
+      ["Integer", 72],
+      ["Integer", 720],
+    ],
+  ])
+}
+
+///|
+test "array for PDF color space" {
+  let s = b"[/DeviceRGB]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[DeviceRGB]")
+  @json.inspect(obj, content=["Array", [["Name", "DeviceRGB"]]])
+}
+
+///|
+test "array with PDF procedure set" {
+  let s = b"[/PDF /Text /ImageB /ImageC /ImageI]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[PDF Text ImageB ImageC ImageI]")
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Name", "PDF"],
+      ["Name", "Text"],
+      ["Name", "ImageB"],
+      ["Name", "ImageC"],
+      ["Name", "ImageI"],
+    ],
+  ])
+}
+
+///|
+test "array with mixed real and integer" {
+  let s = b"[72 72.0 144 144.0]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(string_of_pdf_object(obj), content="[72 72 144 144]")
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 72], ["Real", 72], ["Integer", 144], ["Real", 144]],
+  ])
+}
+
+///|
+test "array with all basic types combined" {
+  let s = b"[123 3.14 true false null /Name <48656C6C6F> 456 0 R]"
+  let tokens = tokenize(s)
+  let obj = parse(tokens)
+  inspect(
+    string_of_pdf_object(obj),
+    content="[123 3.14 true false null Name (Hello) 456 0 R]",
+  )
+  @json.inspect(obj, content=[
+    "Array",
+    [
+      ["Integer", 123],
+      ["Real", 3.14],
+      ["Boolean", true],
+      ["Boolean", false],
+      "Null",
+      ["Name", "Name"],
+      ["String", "Hello"],
+      ["Indirect", 456],
+    ],
+  ])
+}

--- a/parser_test.mbt
+++ b/parser_test.mbt
@@ -181,7 +181,10 @@ test "array with PDF bounding box" {
   let tokens = tokenize(s)
   let obj = parse(tokens)
   inspect(string_of_pdf_object(obj), content="[72 72 540 720]")
-  @json.inspect(obj, content=(["Array",[["Integer",72],["Integer",72],["Integer",540],["Integer",720]]]))
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 72], ["Integer", 72], ["Integer", 540], ["Integer", 720]],
+  ])
 }
 
 ///|
@@ -190,7 +193,10 @@ test "array with PDF dash pattern" {
   let tokens = tokenize(s)
   let obj = parse(tokens)
   inspect(string_of_pdf_object(obj), content="[3 2 1 4]")
-  @json.inspect(obj, content=(["Array",[["Integer",3],["Integer",2],["Integer",1],["Integer",4]]]))
+  @json.inspect(obj, content=[
+    "Array",
+    [["Integer", 3], ["Integer", 2], ["Integer", 1], ["Integer", 4]],
+  ])
 }
 
 ///|

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -26,6 +26,14 @@ pub suberror ParseError {
 }
 
 // Types and methods
+type DICT_BEGIN
+
+type DICT_END
+
+type EOF
+
+type FALSE
+
 pub(all) struct File {
   major : Int
   minor : Int
@@ -37,6 +45,8 @@ impl @fmt.Format for File
 type Func
 impl ToJson for Func
 impl @json.FromJson for Func
+
+type GREATER_THAN_SIGN
 
 pub(all) enum GraphicOperator {
   Op_w(Double)
@@ -117,6 +127,20 @@ pub(all) enum GraphicOperator {
 }
 impl @fmt.Format for GraphicOperator
 
+type INDIRECT
+impl Eq for INDIRECT
+impl Show for INDIRECT
+
+type LEFT_CURLY_BRACE
+
+type LEFT_PARENTHESIS
+
+type LEFT_SQUARE_BRACKET
+
+type LESS_THAN_SIGN
+
+type NULL
+
 type NonTerminal
 impl ToJson for NonTerminal
 impl @json.FromJson for NonTerminal
@@ -147,11 +171,21 @@ impl Show for Position
 impl ToJson for Position
 impl @json.FromJson for Position
 
+type RIGHT_CURLY_BRACE
+
+type RIGHT_PARENTHESIS
+
+type RIGHT_SQUARE_BRACKET
+
+type SOLIDUS
+
 type SourceLocation
 
 pub(all) struct Stream(Bytes)
 #deprecated
 fn Stream::inner(Self) -> Bytes
+
+type TRUE
 
 pub(all) enum Token {
   LEFT_PARENTHESIS
@@ -165,12 +199,14 @@ pub(all) enum Token {
   SOLIDUS
   DICT_BEGIN
   DICT_END
+  NULL
   TRUE
   FALSE
   INTEGER(Int)
   REAL(Double)
   STRING(Bytes)
   NAME(Bytes)
+  INDIRECT(INDIRECT)
   EOF
 }
 fn Token::kind(Self) -> TokenKind
@@ -188,12 +224,14 @@ pub(all) enum TokenKind {
   TK_SOLIDUS
   TK_DICT_BEGIN
   TK_DICT_END
+  TK_NULL
   TK_TRUE
   TK_FALSE
   TK_INTEGER
   TK_REAL
   TK_STRING
   TK_NAME
+  TK_INDIRECT
   TK_EOF
 }
 impl Eq for TokenKind

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -9,7 +9,7 @@ import(
 // Values
 fn ascii_string_of_bytes(Bytes) -> String
 
-fn parse(Array[(Token, Position, Position)], initial_pos? : Position) -> Unit raise ParseError
+fn parse(Array[(Token, Position, Position)], initial_pos? : Position) -> Object raise ParseError
 
 fn tokenize(BytesView) -> Array[(Token, Position, Position)]
 
@@ -158,6 +158,7 @@ pub(all) enum Object {
   Indirect(Int)
 }
 impl @fmt.Format for Object
+impl ToJson for Object
 
 type Parm
 impl ToJson for Parm
@@ -184,6 +185,7 @@ type SourceLocation
 pub(all) struct Stream(Bytes)
 #deprecated
 fn Stream::inner(Self) -> Bytes
+impl ToJson for Stream
 
 type TRUE
 

--- a/token.mbt
+++ b/token.mbt
@@ -34,6 +34,14 @@ pub impl Show for Token with output(self, logger) {
       logger.write_string(value |> ascii_string_of_bytes)
       logger.write_string(")")
     }
+    INDIRECT(value) => {
+      logger.write_string("INDIRECT(")
+      logger.write_string(value.object_num.to_string())
+      logger.write_string(", ")
+      logger.write_string(value.generation_num.to_string())
+      logger.write_string(")")
+    }
     EOF => logger.write_string("EOF")
+    NULL => logger.write_string("NULL")
   }
 }

--- a/token_definition.mbt
+++ b/token_definition.mbt
@@ -11,12 +11,14 @@ pub(all) enum Token {
   SOLIDUS
   DICT_BEGIN
   DICT_END
+  NULL
   TRUE
   FALSE
   INTEGER(Int)
   REAL(Double)
   STRING(Bytes)
   NAME(Bytes)
+  INDIRECT(INDIRECT)
   EOF
 }
 
@@ -34,12 +36,14 @@ pub fn Token::kind(self : Token) -> TokenKind {
     SOLIDUS => TK_SOLIDUS
     DICT_BEGIN => TK_DICT_BEGIN
     DICT_END => TK_DICT_END
+    NULL => TK_NULL
     TRUE => TK_TRUE
     FALSE => TK_FALSE
     INTEGER(_) => TK_INTEGER
     REAL(_) => TK_REAL
     STRING(_) => TK_STRING
     NAME(_) => TK_NAME
+    INDIRECT(_) => TK_INDIRECT
     EOF => TK_EOF
   }
 }
@@ -57,12 +61,14 @@ pub(all) enum TokenKind {
   TK_SOLIDUS
   TK_DICT_BEGIN
   TK_DICT_END
+  TK_NULL
   TK_TRUE
   TK_FALSE
   TK_INTEGER
   TK_REAL
   TK_STRING
   TK_NAME
+  TK_INDIRECT
   TK_EOF
 } derive(Eq)
 
@@ -81,12 +87,14 @@ pub impl Show for TokenKind with output(self, logger) {
       TK_SOLIDUS => "\"/\""
       TK_DICT_BEGIN => "\"<<\""
       TK_DICT_END => "\">>\""
+      TK_NULL => "\"null\""
       TK_TRUE => "\"true\""
       TK_FALSE => "\"false\""
       TK_INTEGER => "INTEGER"
       TK_REAL => "REAL"
       TK_STRING => "STRING"
       TK_NAME => "NAME"
+      TK_INDIRECT => "INDIRECT"
       TK_EOF => "EOF"
     },
   )

--- a/types.mbt
+++ b/types.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(all) struct Stream(Bytes)
+pub(all) struct Stream(Bytes) derive(ToJson)
 
 ///|
 /// pdf object 
@@ -62,7 +62,7 @@ pub(all) enum Object {
   /// endobj
   /// `
   Indirect(Int)
-}
+} derive(ToJson)
 
 ///|
 /// 


### PR DESCRIPTION
feat: add parser for PDF Object

feat: add support for null object in PDF lexer and parser

feat: add handling for NULL token in Show implementation

feat: simplify token string conversion and add NULL handling in parser

feat: expand PDF array tests to cover various data types and structures