### PR TITLE
docs: update documentation for escape sequences in literal strings

### DIFF
--- a/cmark_pdf/utility.mbt
+++ b/cmark_pdf/utility.mbt
@@ -1,16 +1,37 @@
 ///|
-fn pdf_bytes_of_string(s : String) -> Bytes {
-  let buffer = @buffer.new(size_hint=s.length() * 2)
-  for i in 0..<s.length() {
-    let code_unit = s[i]
+/// Convert a String to Bytes suitable for PDF literal strings.
+/// 
+/// if Unicode Code Point not in the ASCII charset, replace it with '?'
+/// 
+/// Escape sequences in literal strings: ref to `ISO 32000-2:2020 (PDF 2.0)`, section 7.3.4.2
+/// 
+/// | Sequence | Measing                   |
+/// |----------|---------------------------|
+/// | `\n`     | LINE FEED                 |
+/// | `\r`     | CARRIAGE RETURN           |
+/// | `\t`     | HORIZONTAL TAB            |
+/// | `\b`     | BACKSPACE                 |
+/// | `\f`     | FORM FEED                 |
+/// | `\(`     | LEFT PARENTHESIS          |
+/// | `\)`     | RIGHT PARENTHESIS         |
+/// | `\\`     | REVERSE SOLIDUS           |
+/// | `\ddd`   | Character code ddd(octal) |
+/// 
+fn pdf_bytes_of_string(non_escape : String) -> Bytes {
+  let buffer = @buffer.new(size_hint=non_escape.length() * 2)
+  for i in 0..<non_escape.length() {
+    let code_unit = non_escape[i]
     if Char::is_ascii(code_unit.unsafe_to_char()) {
       let byte = code_unit.to_byte()
-      // Escape PDF delimiter characters for literal strings
+      // Escape PDF special characters for literal strings
+      // ref: ISO 32000-2:2020 (PDF 2.0), section 7.3.4.2
       match byte {
+        // Backslash - must be escaped
         '\\' => {
           buffer.write_byte(b'\\')
           buffer.write_byte(b'\\')
         }
+        // Parentheses - must be escaped in literal strings
         '(' => {
           buffer.write_byte(b'\\')
           buffer.write_byte(b'(')
@@ -19,6 +40,28 @@ fn pdf_bytes_of_string(s : String) -> Bytes {
           buffer.write_byte(b'\\')
           buffer.write_byte(b')')
         }
+        // Control characters - escape as named sequences
+        '\n' => {
+          buffer.write_byte(b'\\')
+          buffer.write_byte(b'n')
+        }
+        '\r' => {
+          buffer.write_byte(b'\\')
+          buffer.write_byte(b'r')
+        }
+        '\t' => {
+          buffer.write_byte(b'\\')
+          buffer.write_byte(b't')
+        }
+        '\b' => {
+          buffer.write_byte(b'\\')
+          buffer.write_byte(b'b')
+        }
+        '\f' => {
+          buffer.write_byte(b'\\')
+          buffer.write_byte(b'f')
+        }
+        // All other ASCII characters pass through unchanged
         _ => buffer.write_byte(byte)
       }
     } else {
@@ -62,4 +105,102 @@ fn markdown_to_bytes(md_str : String) -> Bytes {
       Op_ET,
     ])
   multiple_page_to_bytes([table_of_contents, ..contents])
+}
+
+///|
+test "pdf_bytes_of_string - basic ASCII text" {
+  let result = pdf_bytes_of_string("Hello World")
+  let expected = b"Hello World"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - backslash escape" {
+  let result = pdf_bytes_of_string("path\\to\\file")
+  let expected = b"path\\\\to\\\\file"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - parentheses escape" {
+  let result = pdf_bytes_of_string("text (with) parentheses")
+  let expected = b"text \\(with\\) parentheses"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - newline escape" {
+  let result = pdf_bytes_of_string("line1\nline2")
+  let expected = b"line1\\nline2"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - carriage return escape" {
+  let result = pdf_bytes_of_string("text\rmore")
+  let expected = b"text\\rmore"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - tab escape" {
+  let result = pdf_bytes_of_string("text\ttab")
+  let expected = b"text\\ttab"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - backspace escape" {
+  let result = pdf_bytes_of_string("text\bbackspace")
+  let expected = b"text\\bbackspace"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - form feed escape" {
+  let result = pdf_bytes_of_string("text\fform")
+  let expected = b"text\\fform"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - all escape sequences combined" {
+  let result = pdf_bytes_of_string("\\()test\n\r\t\b\f")
+  let expected = b"\\\\\\(\\)test\\n\\r\\t\\b\\f"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - non-ASCII replacement" {
+  let result = pdf_bytes_of_string("Hello 世界")
+  let expected = b"Hello ??"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - mixed ASCII and non-ASCII" {
+  let result = pdf_bytes_of_string("ASCII文字mixed")
+  let expected = b"ASCII??mixed"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - empty string" {
+  let result = pdf_bytes_of_string("")
+  let expected = b""
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - only special characters" {
+  let result = pdf_bytes_of_string("\n\r\t\b\f\\()")
+  let expected = b"\\n\\r\\t\\b\\f\\\\\\(\\)"
+  assert_eq(result, expected)
+}
+
+///|
+test "pdf_bytes_of_string - alphanumeric and symbols" {
+  let result = pdf_bytes_of_string("abc123!@#$%^&*-_=+[]{}|;:'\",.<>?/~`")
+  let expected = b"abc123!@#$%^&*-_=+[]{}|;:'\",.<>?/~`"
+  assert_eq(result, expected)
 }


### PR DESCRIPTION
refactor: enhance pdf_bytes_of_string to escape special characters and add comprehensive tests

refactor: rename parameter in pdf_bytes_of_string for clarity and consistency