### PR TITLE
update `illusory0x0/fmt`

### DIFF
--- a/cmark_pdf/moon.pkg.json
+++ b/cmark_pdf/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/x/fs",
     "rami3l/cmark/cmark",
     "illusory0x0/fmt",
+    "illusory0x0/fmt/types",
     "moonbitlang/parser/lexer",
     "moonbitlang/parser/tokens",
     "moonbitlang/parser/basic",

--- a/cmark_pdf/page.mbt
+++ b/cmark_pdf/page.mbt
@@ -1,8 +1,8 @@
 ///|
 fn multiple_page_to_bytes(contents : Array[ContentStream]) -> Bytes {
   let pdf = multiple_pages(contents)
-  let buf = @fmt.Memory::make(@fmt.Format::count(pdf), 0)
-  let offset = @fmt.Format::write(pdf, buf, 0)
+  let buf = @fmt.Memory::make(@fmt.count(pdf), 0)
+  let offset = @fmt.write(pdf, buf, 0)
   @mem_helper.bytes_of_memory(buf, offset)
 }
 

--- a/mem_helper/moon.pkg.json
+++ b/mem_helper/moon.pkg.json
@@ -1,3 +1,3 @@
 {
-  "import": ["illusory0x0/fmt"]
+  "import": ["illusory0x0/fmt", "illusory0x0/fmt/types"]
 }

--- a/mem_helper/pkg.generated.mbti
+++ b/mem_helper/pkg.generated.mbti
@@ -2,13 +2,13 @@
 package "illusory0x0/pdf/mem_helper"
 
 import(
-  "illusory0x0/fmt"
+  "illusory0x0/fmt/types"
 )
 
 // Values
-fn bytes_of_memory(@fmt.Memory, Int) -> Bytes
+fn bytes_of_memory(@types.Memory, Int) -> Bytes
 
-fn string_of_memory(@fmt.Memory, Int) -> String
+fn string_of_memory(@types.Memory, Int) -> String
 
 // Errors
 

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,11 +2,11 @@
   "name": "illusory0x0/pdf",
   "version": "0.1.0",
   "deps": {
-    "illusory0x0/fmt": "0.3.4",
     "moonbitlang/x": "0.4.34",
     "rami3l/cmark": "0.4.0",
     "illusory0x0/lexer": "0.1.0",
-    "moonbitlang/parser": "0.1.7"
+    "moonbitlang/parser": "0.1.7",
+    "illusory0x0/fmt": "0.4.0"
   },
   "bin-deps": {
     "moonbitlang/yacc": "0.6.14"

--- a/pdf_object_parser/moon.pkg.json
+++ b/pdf_object_parser/moon.pkg.json
@@ -11,6 +11,7 @@
   ],
   "test-import": [
     "illusory0x0/fmt",
+    "illusory0x0/fmt/types",
     { "path": "illusory0x0/pdf/types", "alias": "pdf" }
   ],
   "warn-list": "-1-2-3-4-6-7"

--- a/pdf_object_parser/parser_test.mbt
+++ b/pdf_object_parser/parser_test.mbt
@@ -5,8 +5,8 @@ fn bytes_of_memory(mem : @fmt.Memory, len : Int) -> Bytes {
 
 ///|
 fn string_of_pdf_object(obj : @pdf.Object) -> String {
-  let buf = @fmt.Memory::make(@fmt.Format::count(obj), 0)
-  let ofs = @fmt.Format::write(obj, buf, 0)
+  let buf = @fmt.Memory::make(@fmt.count(obj), 0)
+  let ofs = @fmt.write(obj, buf, 0)
   let bytes = bytes_of_memory(buf, ofs)
   ascii_string_of_bytesview(bytes)
 }

--- a/types/content_stream.mbt
+++ b/types/content_stream.mbt
@@ -8,20 +8,20 @@ pub impl @fmt.Format for ContentStream with write(self, buf, start) {
   let xs = self.0
   let mut offset = start
   for x in xs {
-    offset += @fmt.Format::write(x, buf, offset)
+    offset += @fmt.write(x, buf, offset)
   }
   offset - start
 }
 
 ///|
 pub impl @fmt.Format for ContentStream with count(xs) {
-  xs.0.fold(init=0, (acc, x) => @fmt.Format::count(x) + acc)
+  xs.0.fold(init=0, (acc, x) => @fmt.count(x) + acc)
 }
 
 ///|
 pub fn ContentStream::to_stream(self : Self) -> Stream {
-  let buffer = @fmt.Memory::make(@fmt.Format::count(self), 0)
-  let offset = @fmt.Format::write(self, buffer, 0)
+  let buffer = @fmt.Memory::make(@fmt.count(self), 0)
+  let offset = @fmt.write(self, buffer, 0)
   let bytes = @mem_helper.bytes_of_memory(buffer, offset)
   bytes
 }

--- a/types/file.mbt
+++ b/types/file.mbt
@@ -30,7 +30,7 @@ pub impl @fmt.Format for File with write(
     }
     offset += write_pdf_xrefs(xref_offsets, buffer, offset)
     offset += write_pdf_trailer(value.trailer, buffer, offset)
-    offset += @fmt.Format::write(b"startxref\n", buffer, offset)
+    offset += @fmt.write(b"startxref\n", buffer, offset)
     let startxref_offset = offset
     offset += @fmt.format_write(
       b"{}\n%%EOF\n",
@@ -58,7 +58,7 @@ pub impl @fmt.Format for File with count(value : File) -> Int {
   total += count_pdf_trailer(value.trailer)
   total += 11 // "startxref\n"
   let startxref_offset = total
-  total += @fmt.Format::count(startxref_offset)
+  total += @fmt.count(startxref_offset)
   total += 7 // "\n%%EOF\n"
   total
 }
@@ -79,7 +79,7 @@ fn write_pdf_header(pdf : File, buf : @fmt.Memory, start : Int) -> Int {
     //
     offset += @fmt.format_write(
       "%{}\n",
-      [@fmt.BigEndian(0x80818283)],
+      [@fmt.big_endian(0x80818283)],
       buf,
       offset,
     )
@@ -92,9 +92,9 @@ fn write_pdf_header(pdf : File, buf : @fmt.Memory, start : Int) -> Int {
 ///|
 fn count_pdf_header(pdf : File) -> Int {
   5 + // "%PDF-"
-  @fmt.Format::count(pdf.major) +
+  @fmt.count(pdf.major) +
   1 + // "."
-  @fmt.Format::count(pdf.minor) +
+  @fmt.count(pdf.minor) +
   1 + // "\n"
   1 + // "%"
   4 + // BigEndian(0x80818283)
@@ -106,8 +106,8 @@ fn write_pdf_obj(obj : Object, n : Int, buf : @fmt.Memory, start : Int) -> Int {
   try {
     let mut offset = start
     offset += @fmt.format_write("{} 0 obj\n", [n], buf, offset)
-    offset += @fmt.Format::write(obj, buf, offset)
-    offset += @fmt.Format::write(b"\nendobj\n", buf, offset)
+    offset += @fmt.write(obj, buf, offset)
+    offset += @fmt.write(b"\nendobj\n", buf, offset)
     offset - start
   } catch {
     _ => panic()
@@ -116,9 +116,9 @@ fn write_pdf_obj(obj : Object, n : Int, buf : @fmt.Memory, start : Int) -> Int {
 
 ///|
 fn count_pdf_obj(obj : Object, n : Int) -> Int {
-  @fmt.Format::count(n) +
+  @fmt.count(n) +
   7 + // " 0 obj\n"
-  @fmt.Format::count(obj) +
+  @fmt.count(obj) +
   8 // "\nendobj\n"
 }
 
@@ -161,14 +161,14 @@ fn write_pdf_xrefs(
 ) -> Int {
   try {
     let mut offset = start
-    offset += @fmt.Format::write(b"xref\n", buf, offset)
+    offset += @fmt.write(b"xref\n", buf, offset)
     offset += @fmt.format_write(
       b"0 {}\n",
       [xref_offsets.length() + 1],
       buf,
       offset,
     )
-    offset += @fmt.Format::write(b"0000000000 65535 f \n", buf, offset)
+    offset += @fmt.write(b"0000000000 65535 f \n", buf, offset)
     for xref_offset in xref_offsets {
       offset += write_pdf_xref(xref_offset, buf, offset)
     }
@@ -183,7 +183,7 @@ fn count_pdf_xrefs(xref_offsets : Array[Int]) -> Int {
   let mut total = 0
   total += 5 // "xref\n"
   total += 2 // "0 "
-  total += @fmt.Format::count(xref_offsets.length() + 1)
+  total += @fmt.count(xref_offsets.length() + 1)
   total += 1 // "\n"
   total += 18 // "0000000000 65535 f \n"
   for xref_offset in xref_offsets {
@@ -199,15 +199,15 @@ fn write_pdf_trailer(
   start : Int,
 ) -> Int {
   let mut offset = start
-  offset += @fmt.Format::write(b"trailer\n", buf, offset)
-  offset += @fmt.Format::write(trailer_dict, buf, offset)
-  offset += @fmt.Format::write(b"\n", buf, offset)
+  offset += @fmt.write(b"trailer\n", buf, offset)
+  offset += @fmt.write(trailer_dict, buf, offset)
+  offset += @fmt.write(b"\n", buf, offset)
   offset - start
 }
 
 ///|
 fn count_pdf_trailer(trailer_dict : Object) -> Int {
   8 + // "trailer\n"
-  @fmt.Format::count(trailer_dict) +
+  @fmt.count(trailer_dict) +
   1 // "\n"
 }

--- a/types/file_test.mbt
+++ b/types/file_test.mbt
@@ -5,7 +5,7 @@ test "test write to file" {
 
   // Use define_pages helper function
   let pages = @pdf_helper.define_pages(pages=[@pdf.Indirect(4)])
-  let offset = @fmt.Format::write(pages, buf, 0)
+  let offset = @fmt.write(pages, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content=(
@@ -30,14 +30,14 @@ test "test write to file" {
   let op4 = @pdf.Op_Tj(b"Hello, World!")
   let op5 = @pdf.Op_ET
   let content : @pdf.ContentStream = [op1, op2, op3, op4, op5]
-  let offset = @fmt.Format::write(content, buf, 0)
+  let offset = @fmt.write(content, buf, 0)
   let bytes = @mem_helper.bytes_of_memory(buf, offset)
   let len = bytes.length()
   let stm = @pdf.Object::Stream(
     @pdf.Dictionary([("/Length", @pdf.Integer(len))]),
     bytes,
   )
-  let offset = @fmt.Format::write(stm, buf, 0)
+  let offset = @fmt.write(stm, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content=(
@@ -76,7 +76,7 @@ test (t : @test.T) {
   let op4 = @pdf.Op_Tj(b"Hello, World!")
   let op5 = @pdf.Op_ET
   let content : @pdf.ContentStream = [op1, op2, op3, op4, op5]
-  let offset = @fmt.Format::write(content, buf, 0)
+  let offset = @fmt.write(content, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buf, offset),
     content=" 1 0 0 1 50 770 cm BT /F0 36 Tf (Hello, World!) Tj ET",
@@ -111,7 +111,7 @@ test (t : @test.T) {
     parent=@pdf.Indirect(2),
     resources=[font_resources],
   )
-  let offset = @fmt.Format::write(stm, buf, 0)
+  let offset = @fmt.write(stm, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buf, offset),
     content=(
@@ -123,7 +123,7 @@ test (t : @test.T) {
       #|endstream
     ),
   )
-  let offset = @fmt.Format::write(pages, buf, 0)
+  let offset = @fmt.write(pages, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buf, offset),
     content=(
@@ -134,7 +134,7 @@ test (t : @test.T) {
       #|>>
     ),
   )
-  let offset = @fmt.Format::write(catalog, buf, 0)
+  let offset = @fmt.write(catalog, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buf, offset),
     content=(
@@ -144,7 +144,7 @@ test (t : @test.T) {
       #|>>
     ),
   )
-  let offset = @fmt.Format::write(page, buf, 0)
+  let offset = @fmt.write(page, buf, 0)
   inspect(
     @mem_helper.string_of_memory(buf, offset),
     content=(
@@ -166,7 +166,7 @@ test (t : @test.T) {
     ),
   )
   let pdf = @pdf_helper.make_pdf(@pdf.Indirect(3), [stm, pages, catalog, page])
-  let offset = @fmt.Format::write(pdf, buf, 0)
+  let offset = @fmt.write(pdf, buf, 0)
   let pdf_file = @mem_helper.bytes_of_memory(buf, offset)
   @fs.write_bytes_to_file("./output/hello.pdf", pdf_file)
   t.writeln(pdf_file)
@@ -187,7 +187,7 @@ test "image" (t : @test.T) {
     f: 770,
   }
   let content : @pdf.ContentStream = [@pdf.Op_cm(tm), @pdf.Op_Do(b"/Im0")]
-  let offset = @fmt.Format::write(content, buf, 0)
+  let offset = @fmt.write(content, buf, 0)
   let bytes = @mem_helper.bytes_of_memory(buf, offset)
   let len = bytes.length()
 
@@ -235,7 +235,7 @@ test "image" (t : @test.T) {
   let pdf = @pdf_helper.make_pdf(@pdf.Indirect(3), [
     stm, pages, catalog, page, image, icc,
   ])
-  let offset = @fmt.Format::write(pdf, buf, 0)
+  let offset = @fmt.write(pdf, buf, 0)
   let bytes = @mem_helper.bytes_of_memory(buf, offset)
   @fs.write_bytes_to_file("./output/ocaml.pdf", bytes)
   t.writeln(bytes)

--- a/types/graphic_operator.mbt
+++ b/types/graphic_operator.mbt
@@ -173,105 +173,105 @@ pub impl @fmt.Format for GraphicOperator with write(
 pub impl @fmt.Format for GraphicOperator with count(value : GraphicOperator) -> Int {
   match value {
     // " {} w" = 1 + count(w) + 2 = count(w) + 3
-    Op_w(w) => @fmt.Format::count(w) + 3
+    Op_w(w) => @fmt.count(w) + 3
     // " {} J" = 1 + count(j) + 2 = count(j) + 3  
-    Op_J(j) => @fmt.Format::count(j) + 3
+    Op_J(j) => @fmt.count(j) + 3
     // " {} j" = 1 + count(j) + 2 = count(j) + 3
-    Op_j(j) => @fmt.Format::count(j) + 3
+    Op_j(j) => @fmt.count(j) + 3
     // " {} M" = 1 + count(m) + 2 = count(m) + 3
-    Op_M(m) => @fmt.Format::count(m) + 3
+    Op_M(m) => @fmt.count(m) + 3
     // " {} {} {} {} {} {} cm" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 1 + count(e) + 1 + count(f) + 3
     Op_cm(t) =>
       1 +
-      @fmt.Format::count(t.a) +
+      @fmt.count(t.a) +
       1 +
-      @fmt.Format::count(t.b) +
+      @fmt.count(t.b) +
       1 +
-      @fmt.Format::count(t.c) +
+      @fmt.count(t.c) +
       1 +
-      @fmt.Format::count(t.d) +
+      @fmt.count(t.d) +
       1 +
-      @fmt.Format::count(t.e) +
+      @fmt.count(t.e) +
       1 +
-      @fmt.Format::count(t.f) +
+      @fmt.count(t.f) +
       3
     // " BT" = 3
     Op_BT => 3
     // " ET" = 3  
     Op_ET => 3
     // " {} {} Tf" = 1 + count(k) + 1 + count(s) + 3
-    Op_Tf(k, s) => 1 + @fmt.Format::count(k) + 1 + @fmt.Format::count(s) + 3
+    Op_Tf(k, s) => 1 + @fmt.count(k) + 1 + @fmt.count(s) + 3
     // " ({}) Tj" = 2 + count(s) + 4
-    Op_Tj(s) => 2 + @fmt.Format::count(s) + 4
+    Op_Tj(s) => 2 + @fmt.count(s) + 4
     // " {} ... {} d" = sum of (" {}" for each f) + " {} d"
     Op_d(fl, y) =>
-      fl.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) +
+      fl.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) +
       1 +
-      @fmt.Format::count(y) +
+      @fmt.count(y) +
       2
     // " {} ri" = 1 + count(s) + 3
-    Op_ri(s) => 1 + @fmt.Format::count(s) + 3
+    Op_ri(s) => 1 + @fmt.count(s) + 3
     // " {} i" = 1 + count(i) + 2
-    Op_i(i) => 1 + @fmt.Format::count(i) + 2
+    Op_i(i) => 1 + @fmt.count(i) + 2
     // " {} gs" = 1 + count(s) + 3
-    Op_gs(s) => 1 + @fmt.Format::count(s) + 3
+    Op_gs(s) => 1 + @fmt.count(s) + 3
     // " q" = 2
     Op_q => 2
     // " Q" = 2
     Op_Q => 2
     // " {} {} m" = 1 + count(a) + 1 + count(b) + 2
-    Op_m(a, b) => 1 + @fmt.Format::count(a) + 1 + @fmt.Format::count(b) + 2
+    Op_m(a, b) => 1 + @fmt.count(a) + 1 + @fmt.count(b) + 2
     // " {} {} l" = 1 + count(a) + 1 + count(b) + 2
-    Op_l(a, b) => 1 + @fmt.Format::count(a) + 1 + @fmt.Format::count(b) + 2
+    Op_l(a, b) => 1 + @fmt.count(a) + 1 + @fmt.count(b) + 2
     // " {} {} {} {} {} {} c" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 1 + count(e) + 1 + count(k) + 2
     Op_c(a, b, c, d, e, k) =>
       1 +
-      @fmt.Format::count(a) +
+      @fmt.count(a) +
       1 +
-      @fmt.Format::count(b) +
+      @fmt.count(b) +
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(d) +
+      @fmt.count(d) +
       1 +
-      @fmt.Format::count(e) +
+      @fmt.count(e) +
       1 +
-      @fmt.Format::count(k) +
+      @fmt.count(k) +
       2
     // " {} {} {} {} v" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 2
     Op_v(a, b, c, d) =>
       1 +
-      @fmt.Format::count(a) +
+      @fmt.count(a) +
       1 +
-      @fmt.Format::count(b) +
+      @fmt.count(b) +
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(d) +
+      @fmt.count(d) +
       2
     // " {} {} {} {} y" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 2
     Op_y(a, b, c, d) =>
       1 +
-      @fmt.Format::count(a) +
+      @fmt.count(a) +
       1 +
-      @fmt.Format::count(b) +
+      @fmt.count(b) +
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(d) +
+      @fmt.count(d) +
       2
     // " h" = 2
     Op_h => 2
     // " {} {} {} {} re" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 3
     Op_re(a, b, c, d) =>
       1 +
-      @fmt.Format::count(a) +
+      @fmt.count(a) +
       1 +
-      @fmt.Format::count(b) +
+      @fmt.count(b) +
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(d) +
+      @fmt.count(d) +
       3
     // " S" = 2
     Op_S => 2
@@ -298,153 +298,130 @@ pub impl @fmt.Format for GraphicOperator with count(value : GraphicOperator) -> 
     // " W*" = 3
     Op_W_star => 3
     // " {} Tc" = 1 + count(c) + 3
-    Op_Tc(c) => 1 + @fmt.Format::count(c) + 3
+    Op_Tc(c) => 1 + @fmt.count(c) + 3
     // " {} Tw" = 1 + count(w) + 3
-    Op_Tw(w) => 1 + @fmt.Format::count(w) + 3
+    Op_Tw(w) => 1 + @fmt.count(w) + 3
     // " {} Tz" = 1 + count(z) + 3
-    Op_Tz(z) => 1 + @fmt.Format::count(z) + 3
+    Op_Tz(z) => 1 + @fmt.count(z) + 3
     // " {} TL" = 1 + count(l) + 3
-    Op_TL(l) => 1 + @fmt.Format::count(l) + 3
+    Op_TL(l) => 1 + @fmt.count(l) + 3
     // " {} Tr" = 1 + count(i) + 3
-    Op_Tr(i) => 1 + @fmt.Format::count(i) + 3
+    Op_Tr(i) => 1 + @fmt.count(i) + 3
     // " {} Ts" = 1 + count(r) + 3
-    Op_Ts(r) => 1 + @fmt.Format::count(r) + 3
+    Op_Ts(r) => 1 + @fmt.count(r) + 3
     // " {} {} Td" = 1 + count(k) + 1 + count(k_) + 3
-    Op_Td(k, k_) => 1 + @fmt.Format::count(k) + 1 + @fmt.Format::count(k_) + 3
+    Op_Td(k, k_) => 1 + @fmt.count(k) + 1 + @fmt.count(k_) + 3
     // " {} {} TD" = 1 + count(k) + 1 + count(k_) + 3
-    Op_TD(k, k_) => 1 + @fmt.Format::count(k) + 1 + @fmt.Format::count(k_) + 3
+    Op_TD(k, k_) => 1 + @fmt.count(k) + 1 + @fmt.count(k_) + 3
     // " {} {} {} {} {} {} Tm" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 1 + count(e) + 1 + count(f) + 3
     Op_Tm(t) =>
       1 +
-      @fmt.Format::count(t.a) +
+      @fmt.count(t.a) +
       1 +
-      @fmt.Format::count(t.b) +
+      @fmt.count(t.b) +
       1 +
-      @fmt.Format::count(t.c) +
+      @fmt.count(t.c) +
       1 +
-      @fmt.Format::count(t.d) +
+      @fmt.count(t.d) +
       1 +
-      @fmt.Format::count(t.e) +
+      @fmt.count(t.e) +
       1 +
-      @fmt.Format::count(t.f) +
+      @fmt.count(t.f) +
       3
     // " T*" = 3
     Op_T_star => 3
     // " " + count(obj) + " TJ" = 1 + count(obj) + 3
-    Op_TJ(obj) => 1 + @fmt.Format::count(obj) + 3
+    Op_TJ(obj) => 1 + @fmt.count(obj) + 3
     // " {}'" = 1 + count(s) + 1
-    Op_single_quote(s) => 1 + @fmt.Format::count(s) + 1 + 2
+    Op_single_quote(s) => 1 + @fmt.count(s) + 1 + 2
     // " {} {} {} \"" = 1 + count(k) + 1 + count(k_) + 1 + count(s) + 2
     Op_double_quote(k, k_, s) =>
-      1 +
-      @fmt.Format::count(k) +
-      1 +
-      @fmt.Format::count(k_) +
-      1 +
-      @fmt.Format::count(s) +
-      2
+      1 + @fmt.count(k) + 1 + @fmt.count(k_) + 1 + @fmt.count(s) + 2
     // " {} {} d0" = 1 + count(k) + 1 + count(k_) + 3
-    Op_d0(k, k_) => 1 + @fmt.Format::count(k) + 1 + @fmt.Format::count(k_) + 3
+    Op_d0(k, k_) => 1 + @fmt.count(k) + 1 + @fmt.count(k_) + 3
     // " {} {} {} {} {} {} d1" = 1 + count(a) + 1 + count(b) + 1 + count(c) + 1 + count(d) + 1 + count(e) + 1 + count(k) + 3
     Op_d1(a, b, c, d, e, k) =>
       1 +
-      @fmt.Format::count(a) +
+      @fmt.count(a) +
       1 +
-      @fmt.Format::count(b) +
+      @fmt.count(b) +
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(d) +
+      @fmt.count(d) +
       1 +
-      @fmt.Format::count(e) +
+      @fmt.count(e) +
       1 +
-      @fmt.Format::count(k) +
+      @fmt.count(k) +
       3
     // " {} CS" = 1 + count(s) + 3
-    Op_CS(s) => 1 + @fmt.Format::count(s) + 3
+    Op_CS(s) => 1 + @fmt.count(s) + 3
     // " {} cs" = 1 + count(s) + 3
-    Op_cs(s) => 1 + @fmt.Format::count(s) + 3
+    Op_cs(s) => 1 + @fmt.count(s) + 3
     // sum of (" {}" for each f) + " SC"
-    Op_SC(fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) + 3
+    Op_SC(fs) => fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) + 3
     // sum of (" {}" for each f) + " SCN"
-    Op_SCN(fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) + 4
+    Op_SCN(fs) => fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) + 4
     // sum of (" {}" for each f) + " scn"
-    Op_scn(fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) + 4
+    Op_scn(fs) => fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) + 4
     // sum of (" {}" for each f) + " {} scn"
     Op_scnName(s, fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) +
+      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) +
       1 +
-      @fmt.Format::count(s) +
+      @fmt.count(s) +
       4
     // sum of (" {}" for each f) + " {} SCN"
     Op_SCNName(s, fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) +
+      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) +
       1 +
-      @fmt.Format::count(s) +
+      @fmt.count(s) +
       4
     // " {} G" = 1 + count(k) + 2
-    Op_G(k) => 1 + @fmt.Format::count(k) + 2
+    Op_G(k) => 1 + @fmt.count(k) + 2
     // " {} g" = 1 + count(k) + 2
-    Op_g(k) => 1 + @fmt.Format::count(k) + 2
+    Op_g(k) => 1 + @fmt.count(k) + 2
     // " {} {} {} Rg" = 1 + count(r) + 1 + count(g) + 1 + count(b) + 3
     Op_RG(r, g, b) =>
-      1 +
-      @fmt.Format::count(r) +
-      1 +
-      @fmt.Format::count(g) +
-      1 +
-      @fmt.Format::count(b) +
-      3
+      1 + @fmt.count(r) + 1 + @fmt.count(g) + 1 + @fmt.count(b) + 3
     // " {} {} {} rg" = 1 + count(r) + 1 + count(g) + 1 + count(b) + 3
     Op_rg(r, g, b) =>
-      1 +
-      @fmt.Format::count(r) +
-      1 +
-      @fmt.Format::count(g) +
-      1 +
-      @fmt.Format::count(b) +
-      3
+      1 + @fmt.count(r) + 1 + @fmt.count(g) + 1 + @fmt.count(b) + 3
     // " {} {} {} {} K" = 1 + count(c) + 1 + count(m) + 1 + count(y) + 1 + count(k) + 2
     Op_K(c, m, y, k) =>
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(m) +
+      @fmt.count(m) +
       1 +
-      @fmt.Format::count(y) +
+      @fmt.count(y) +
       1 +
-      @fmt.Format::count(k) +
+      @fmt.count(k) +
       2
     // " {} {} {} {} k" = 1 + count(c) + 1 + count(m) + 1 + count(y) + 1 + count(k) + 2
     Op_k(c, m, y, k) =>
       1 +
-      @fmt.Format::count(c) +
+      @fmt.count(c) +
       1 +
-      @fmt.Format::count(m) +
+      @fmt.count(m) +
       1 +
-      @fmt.Format::count(y) +
+      @fmt.count(y) +
       1 +
-      @fmt.Format::count(k) +
+      @fmt.count(k) +
       2
     // " {} sh" = 1 + count(s) + 3
-    Op_sh(s) => 1 + @fmt.Format::count(s) + 3
+    Op_sh(s) => 1 + @fmt.count(s) + 3
     // " BI {} ID {} EI" = 4 + count(dict) + 4 + count(data) + 3
-    InlineImage(dict, data) =>
-      4 + @fmt.Format::count(dict) + 4 + @fmt.Format::count(data) + 3
+    InlineImage(dict, data) => 4 + @fmt.count(dict) + 4 + @fmt.count(data) + 3
     // " {} Do" = 1 + count(s) + 3
-    Op_Do(s) => 1 + @fmt.Format::count(s) + 3
+    Op_Do(s) => 1 + @fmt.count(s) + 3
     // " {} MP" = 1 + count(s) + 3
-    Op_MP(s) => 1 + @fmt.Format::count(s) + 3
+    Op_MP(s) => 1 + @fmt.count(s) + 3
     // " {} " + count(o) + " DP" = 1 + count(s) + 1 + count(o) + 3
-    Op_DP(s, o) => 1 + @fmt.Format::count(s) + 1 + @fmt.Format::count(o) + 3
+    Op_DP(s, o) => 1 + @fmt.count(s) + 1 + @fmt.count(o) + 3
     // " {} BMC" = 1 + count(s) + 4
-    Op_BMC(s) => 1 + @fmt.Format::count(s) + 4
+    Op_BMC(s) => 1 + @fmt.count(s) + 4
     // " {} " + count(obj) + " BDC" = 1 + count(s) + 1 + count(obj) + 4
-    Op_BDC(s, obj) =>
-      1 + @fmt.Format::count(s) + 1 + @fmt.Format::count(obj) + 4
+    Op_BDC(s, obj) => 1 + @fmt.count(s) + 1 + @fmt.count(obj) + 4
     // " EMC" = 4
     Op_EMC => 4
     // " Bx" = 3
@@ -452,11 +429,10 @@ pub impl @fmt.Format for GraphicOperator with count(value : GraphicOperator) -> 
     // returns 0
     Op_Unknown(_) => 0
     // " % {}\n" = 3 + count(s) + 1
-    Op_Comment(s) => 3 + @fmt.Format::count(s) + 1
+    Op_Comment(s) => 3 + @fmt.count(s) + 1
     // " EX" = 3
     OP_EX => 3
     // sum of (" {}" for each f) + " sc"
-    Op_sc(fs) =>
-      fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.Format::count(f) }) + 3
+    Op_sc(fs) => fs.fold(init=0, fn(acc, f) { acc + 1 + @fmt.count(f) }) + 3
   }
 }

--- a/types/moon.pkg.json
+++ b/types/moon.pkg.json
@@ -1,6 +1,7 @@
 {
   "import": [
     "illusory0x0/fmt",
+    "illusory0x0/fmt/types",
     "illusory0x0/fmt/padding",
     "illusory0x0/pdf/mem_helper",
     "illusory0x0/pdf/helper"

--- a/types/object.mbt
+++ b/types/object.mbt
@@ -11,19 +11,19 @@ fn write_pdf_string(
   start : Int,
 ) -> Int {
   let mut offset = start
-  offset += @fmt.Format::write(b"(", buffer, offset)
+  offset += @fmt.write(b"(", buffer, offset)
   for x in pdf_string {
     match x {
       '(' | ')' | '\\' as c => {
-        offset += @fmt.Format::write(b"\\", buffer, offset)
+        offset += @fmt.write(b"\\", buffer, offset)
         buffer[offset] = c
         offset += 1
       }
-      '\n' => offset += @fmt.Format::write(b"\\n", buffer, offset)
-      '\r' => offset += @fmt.Format::write(b"\\r", buffer, offset)
-      '\t' => offset += @fmt.Format::write(b"\\t", buffer, offset)
-      '\b' => offset += @fmt.Format::write(b"\\b", buffer, offset)
-      '\x0c' => offset += @fmt.Format::write(b"\\f", buffer, offset)
+      '\n' => offset += @fmt.write(b"\\n", buffer, offset)
+      '\r' => offset += @fmt.write(b"\\r", buffer, offset)
+      '\t' => offset += @fmt.write(b"\\t", buffer, offset)
+      '\b' => offset += @fmt.write(b"\\b", buffer, offset)
+      '\x0c' => offset += @fmt.write(b"\\f", buffer, offset)
       c => {
         // here we do not handle octal escape sequence for some non-printable ASCII characters
         buffer[offset] = c
@@ -31,7 +31,7 @@ fn write_pdf_string(
       }
     }
   }
-  offset += @fmt.Format::write(b")", buffer, offset)
+  offset += @fmt.write(b")", buffer, offset)
   offset - start
 }
 
@@ -41,13 +41,13 @@ fn write_pdf_name(pdf_name : Bytes, buffer : @fmt.Memory, start : Int) -> Int {
   if needs_processing(pdf_name) {
     if pdf_name == b"" || pdf_name[0] != '/' {
       println("warning: bad name")
-      offset += @fmt.Format::write(b"/", buffer, offset)
+      offset += @fmt.write(b"/", buffer, offset)
     } else {
-      offset += @fmt.Format::write(b"/", buffer, offset)
+      offset += @fmt.write(b"/", buffer, offset)
       offset += write_pdf_name_inner(pdf_name, buffer, offset)
     }
   } else {
-    offset += @fmt.Format::write(pdf_name, buffer, offset)
+    offset += @fmt.write(pdf_name, buffer, offset)
   }
   offset - start
 }
@@ -68,25 +68,17 @@ fn write_pdf_name_inner(
     match ch {
       '\x00' => {
         println("Warning: name \{pdf_name} contains the null character\n")
-        offset += @fmt.Format::write(b"#00", buffer, offset)
+        offset += @fmt.write(b"#00", buffer, offset)
       }
       // outside the range of ``!'' (0x21) to ``~'' (0x7E)
       // should be written in `#xx` notation
       //
       h if h < '\x21' || h > '\x7e' || is_delimiter(h) || h == '#' => {
-        offset += @fmt.Format::write(b"#", buffer, offset)
+        offset += @fmt.write(b"#", buffer, offset)
         // write high nibble
-        offset += @fmt.Format::write(
-          HEX_DIGITS[h.to_int() / 16],
-          buffer,
-          offset,
-        )
+        offset += @fmt.write(HEX_DIGITS[h.to_int() / 16], buffer, offset)
         // write low nibble
-        offset += @fmt.Format::write(
-          HEX_DIGITS[h.to_int() % 16],
-          buffer,
-          offset,
-        )
+        offset += @fmt.write(HEX_DIGITS[h.to_int() % 16], buffer, offset)
       }
       h => {
         buffer[offset] = h
@@ -126,69 +118,69 @@ pub impl @fmt.Format for Object with write(
 ) -> Int {
   try {
     match value {
-      Null => @fmt.Format::write(b"null", buffer, start)
-      Boolean(true) => @fmt.Format::write(b"true", buffer, start)
-      Boolean(false) => @fmt.Format::write(b"false", buffer, start)
-      Integer(n) => @fmt.Format::write(n, buffer, start)
-      Real(r) => @fmt.Format::write(r, buffer, start)
+      Null => @fmt.write(b"null", buffer, start)
+      Boolean(true) => @fmt.write(b"true", buffer, start)
+      Boolean(false) => @fmt.write(b"false", buffer, start)
+      Integer(n) => @fmt.write(n, buffer, start)
+      Real(r) => @fmt.write(r, buffer, start)
       String(s) => write_pdf_string(s, buffer, start)
       Name(n) => write_pdf_name(n, buffer, start)
       Array(elts) => {
         let mut offset = start
         match elts {
-          [] => offset += @fmt.Format::write(b"[]", buffer, offset)
+          [] => offset += @fmt.write(b"[]", buffer, offset)
           [x] => {
-            offset += @fmt.Format::write(b"[", buffer, offset)
-            offset += @fmt.Format::write(x, buffer, offset)
-            offset += @fmt.Format::write(b"]", buffer, offset)
+            offset += @fmt.write(b"[", buffer, offset)
+            offset += @fmt.write(x, buffer, offset)
+            offset += @fmt.write(b"]", buffer, offset)
           }
           [x, .. xs] => {
-            offset += @fmt.Format::write(b"[", buffer, offset)
-            offset += @fmt.Format::write(x, buffer, offset)
+            offset += @fmt.write(b"[", buffer, offset)
+            offset += @fmt.write(x, buffer, offset)
             for x in xs {
-              offset += @fmt.Format::write(b" ", buffer, offset)
-              offset += @fmt.Format::write(x, buffer, offset)
+              offset += @fmt.write(b" ", buffer, offset)
+              offset += @fmt.write(x, buffer, offset)
             }
-            offset += @fmt.Format::write(b"]", buffer, offset)
+            offset += @fmt.write(b"]", buffer, offset)
           }
         }
         offset - start
       }
       Dictionary(entries) => {
         let mut offset = start
-        offset += @fmt.Format::write(b"<<\n", buffer, offset)
+        offset += @fmt.write(b"<<\n", buffer, offset)
         match entries {
           [] => ()
           [(key, value)] => {
-            offset += @fmt.Format::write(b"  ", buffer, offset)
-            offset += @fmt.Format::write(key, buffer, offset)
-            offset += @fmt.Format::write(b" ", buffer, offset)
-            offset += @fmt.Format::write(value, buffer, offset)
+            offset += @fmt.write(b"  ", buffer, offset)
+            offset += @fmt.write(key, buffer, offset)
+            offset += @fmt.write(b" ", buffer, offset)
+            offset += @fmt.write(value, buffer, offset)
           }
           [(key, value), .. xs] => {
-            offset += @fmt.Format::write(b"  ", buffer, offset)
-            offset += @fmt.Format::write(key, buffer, offset)
-            offset += @fmt.Format::write(b" ", buffer, offset)
-            offset += @fmt.Format::write(value, buffer, offset)
+            offset += @fmt.write(b"  ", buffer, offset)
+            offset += @fmt.write(key, buffer, offset)
+            offset += @fmt.write(b" ", buffer, offset)
+            offset += @fmt.write(value, buffer, offset)
             for x in xs {
               let (key, value) = x
-              offset += @fmt.Format::write(b"  ", buffer, offset)
-              offset += @fmt.Format::write(b"\n  ", buffer, offset)
-              offset += @fmt.Format::write(key, buffer, offset)
-              offset += @fmt.Format::write(b" ", buffer, offset)
-              offset += @fmt.Format::write(value, buffer, offset)
+              offset += @fmt.write(b"  ", buffer, offset)
+              offset += @fmt.write(b"\n  ", buffer, offset)
+              offset += @fmt.write(key, buffer, offset)
+              offset += @fmt.write(b" ", buffer, offset)
+              offset += @fmt.write(value, buffer, offset)
             }
           }
         }
-        offset += @fmt.Format::write(b"\n>>", buffer, offset)
+        offset += @fmt.write(b"\n>>", buffer, offset)
         offset - start
       }
       Stream(dict, data) => {
         let mut offset = start
-        offset += @fmt.Format::write(dict, buffer, offset)
-        offset += @fmt.Format::write(b"\nstream\n", buffer, offset)
-        offset += @fmt.Format::write(data.inner(), buffer, offset)
-        offset += @fmt.Format::write(b"\nendstream", buffer, offset)
+        offset += @fmt.write(dict, buffer, offset)
+        offset += @fmt.write(b"\nstream\n", buffer, offset)
+        offset += @fmt.write(data.inner(), buffer, offset)
+        offset += @fmt.write(b"\nendstream", buffer, offset)
         offset - start
       }
       Indirect(n) => @fmt.format_write(b"{} 0 R", [n], buffer, start)
@@ -204,18 +196,17 @@ pub impl @fmt.Format for Object with count(value : Object) -> Int {
     Null => 4 // "null"
     Boolean(true) => 4 // "true"
     Boolean(false) => 5 // "false"
-    Integer(n) => @fmt.Format::count(n)
-    Real(r) => @fmt.Format::count(r)
+    Integer(n) => @fmt.count(n)
+    Real(r) => @fmt.count(r)
     String(s) => s.length() * 2 + 2 // simplified as requested: multiply by 2 + parentheses
     Name(n) => n.length() * 2 // simplified as requested: multiply by 2
     Array(elts) =>
       match elts {
         [] => 2 // "[]"
-        [x] => 2 + @fmt.Format::count(x) // "[" + element + "]"
+        [x] => 2 + @fmt.count(x) // "[" + element + "]"
         _ => {
           // "[" + first_element + (" " + element)* + "]"
-          let content_count = elts.fold(init=0, (acc, x) => acc +
-            @fmt.Format::count(x))
+          let content_count = elts.fold(init=0, (acc, x) => acc + @fmt.count(x))
           let spaces_count = elts.length() - 1 // spaces between elements
           2 + content_count + spaces_count
         }
@@ -225,24 +216,20 @@ pub impl @fmt.Format for Object with count(value : Object) -> Int {
         [] => 6 // "<<\n\n>>"
         [(key, value)] =>
           // "<<\n  " + key + " " + value + "\n>>"
-          6 + 2 + key.length() * 2 + 1 + @fmt.Format::count(value)
+          6 + 2 + key.length() * 2 + 1 + @fmt.count(value)
         [(key, value), .. xs] => {
           // "<<\n  " + first_entry + ("\n  " + key + " " + value)* + "\n>>"
-          let mut total = 6 +
-            2 +
-            key.length() * 2 +
-            1 +
-            @fmt.Format::count(value)
+          let mut total = 6 + 2 + key.length() * 2 + 1 + @fmt.count(value)
           for x in xs {
             let (k, v) = x
-            total += 4 + k.length() * 2 + 1 + @fmt.Format::count(v) // "\n  " + key + " " + value
+            total += 4 + k.length() * 2 + 1 + @fmt.count(v) // "\n  " + key + " " + value
           }
           total
         }
       }
     Stream(dict, data) =>
       // dict + "\nstream\n" + data + "\nendstream"
-      @fmt.Format::count(dict) + 9 + data.inner().length() + 10
-    Indirect(n) => @fmt.Format::count(n) + 4 // number + " 0 R"
+      @fmt.count(dict) + 9 + data.inner().length() + 10
+    Indirect(n) => @fmt.count(n) + 4 // number + " 0 R"
   }
 }

--- a/types/object_test.mbt
+++ b/types/object_test.mbt
@@ -2,37 +2,37 @@
 test "@fmt.Format for Object" {
   let buffer = @fmt.Memory::make(4096, Byte::default())
   let value = @pdf.Object::Integer(42)
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="42")
   let value = @pdf.Null
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="null")
   let value = @pdf.Boolean(true)
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="true")
   let value = @pdf.Boolean(false)
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="false")
   let value = @pdf.Real(3.14)
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="3.14")
   let value = @pdf.String(b"Hello, World!")
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content="(Hello, World!)",
   )
   let value = @pdf.Name(b"/Name")
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="/Name")
   let value = @pdf.Array([@pdf.Integer(1), @pdf.Integer(2), @pdf.Integer(3)])
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="[1 2 3]")
   let value = @pdf.Dictionary([
     ("/Type", @pdf.Name(b"/Example")),
     ("/Count", @pdf.Integer(3)),
   ])
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content=(
@@ -46,7 +46,7 @@ test "@fmt.Format for Object" {
     @pdf.Dictionary([("/Length", @pdf.Integer(11))]),
     b"Hello World",
   )
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content=(
@@ -59,14 +59,14 @@ test "@fmt.Format for Object" {
     ),
   )
   let value = @pdf.Indirect(1)
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="1 0 R")
   let value = @pdf.Dictionary([
     ("/Type", @pdf.Name(b"/Pages")),
     ("/Kids", @pdf.Integer(1)),
     ("/Count", @pdf.Integer(1)),
   ])
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(
     @mem_helper.string_of_memory(buffer, offset),
     content=(
@@ -78,7 +78,7 @@ test "@fmt.Format for Object" {
     ),
   )
   let value = @pdf.Array([@pdf.Indirect(1)])
-  let offset = @fmt.Format::write(value, buffer, 0)
+  let offset = @fmt.write(value, buffer, 0)
   inspect(@mem_helper.string_of_memory(buffer, offset), content="[1 0 R]")
 }
 

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -1,10 +1,6 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "illusory0x0/pdf/types"
 
-import(
-  "illusory0x0/fmt"
-)
-
 // Values
 
 // Errors
@@ -16,7 +12,7 @@ fn ContentStream::inner(Self) -> Array[GraphicOperator]
 fn ContentStream::iter(Self) -> Iter[GraphicOperator]
 fn ContentStream::to_stream(Self) -> Stream
 fn ContentStream::to_stream_object(Self) -> Object
-impl @fmt.Format for ContentStream
+impl @illusory0x0/fmt/types.Format for ContentStream
 impl ToJson for ContentStream
 
 pub(all) struct File {
@@ -25,7 +21,7 @@ pub(all) struct File {
   objects : Array[Object]
   trailer : Object
 }
-impl @fmt.Format for File
+impl @illusory0x0/fmt/types.Format for File
 impl ToJson for File
 
 pub(all) enum GraphicOperator {
@@ -105,7 +101,7 @@ pub(all) enum GraphicOperator {
   Op_Unknown(Bytes)
   Op_Comment(Bytes)
 }
-impl @fmt.Format for GraphicOperator
+impl @illusory0x0/fmt/types.Format for GraphicOperator
 impl ToJson for GraphicOperator
 
 pub(all) enum Object {
@@ -120,7 +116,7 @@ pub(all) enum Object {
   Stream(Object, Stream)
   Indirect(Int)
 }
-impl @fmt.Format for Object
+impl @illusory0x0/fmt/types.Format for Object
 impl ToJson for Object
 
 pub(all) enum StandardFont {


### PR DESCRIPTION
Refactor formatting functions to simplify usage

- Updated calls to formatting functions in various modules to use the new simplified syntax.
- Replaced instances of `@fmt.Format::write` and `@fmt.Format::count` with `@fmt.write` and `@fmt.count` respectively for consistency and clarity.
- Adjusted related tests to ensure they align with the new formatting function calls.